### PR TITLE
Project name renamed

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,4 +5,4 @@ pluginManagement {
     }
 }
 
-rootProject.name = "gherlint-intellij"
+rootProject.name = "gherlintellij"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,11 +1,11 @@
 <!-- Plugin Configuration File. Read more: https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html -->
 <idea-plugin>
   <!-- Unique identifier of the plugin. It should be FQN. It cannot be changed between the plugin versions. -->
-  <id>com.gherlint.gherlint-intellij</id>
+  <id>com.gherlint.gherlintellij</id>
 
   <!-- Public plugin name should be written in Title Case.
        Guidelines: https://plugins.jetbrains.com/docs/marketplace/plugin-overview-page.html#plugin-name -->
-  <name>Gherlint-intellij</name>
+  <name>Gherkin Linter</name>
 
   <!-- A displayed Vendor name or Organization ID displayed on the Plugins Page. -->
   <vendor email="support@yourcompany.com" url="https://www.yourcompany.com">YourCompany</vendor>


### PR DESCRIPTION
Rename the project name to meet the IntelliJ Plugins naming standard. (*Word like `intellij` must not be use)